### PR TITLE
Clarify virtualenv vs project directory confusion.

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -5,11 +5,12 @@ Getting started
 
 .. code-block:: shell
 
-    $ virtualenv my_project
-    $ source my_project/bin/activate
-    $ pip install ramses
-    $ pcreate -s ramses_starter my_project
+    $ mkdir my_project
     $ cd my_project
+    $ virtualenv venv
+    $ source venv/bin/activate
+    $ pip install ramses
+    $ pcreate -s ramses_starter .
     $ pserve local.ini
 
 2. Tada! Start editing api.raml to modify the API and items.json for the schema.


### PR DESCRIPTION
Closes #114 

------
This is updated version of #115 and based on `develop`, instead of `master`.