### PR TITLE
docs: Fix simple typo, persmissions -> permissions

### DIFF
--- a/docs/source/schemas.rst
+++ b/docs/source/schemas.rst
@@ -20,7 +20,7 @@ All Ramses-specific properties are prefixed with an underscore.
 Showing Fields
 --------------
 
-If you've enabled authentication, you can list which fields to return to authenticated users in ``_auth_fields`` and to non-authenticated users in ``_public_fields``. Additionaly, you can list fields to be hidden but remain hidden (with proper persmissions) in ``_hidden_fields``.
+If you've enabled authentication, you can list which fields to return to authenticated users in ``_auth_fields`` and to non-authenticated users in ``_public_fields``. Additionaly, you can list fields to be hidden but remain hidden (with proper permissions) in ``_hidden_fields``.
 
 .. code-block:: json
 


### PR DESCRIPTION
There is a small typo in docs/source/schemas.rst.

Should read `permissions` rather than `persmissions`.

